### PR TITLE
Added upgrade flag to pyvmomi install

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ sudo apt-get install python3-pip
 
 # Ansible Requirements  
 pip3 install pyvim  
-pip3 install pyvmomi  
+pip3 install --upgrade pyvmomi  
 
 # Ansible Galaxy Requirements  
 ansible-galaxy collection install community.vmware  


### PR DESCRIPTION
On my system the pip3 install pyvmomi failed.  Adding the --upgrade flag allowed it to install (seems due to urllib3 version 1.26.2 at the time of this).